### PR TITLE
Add v4l launch files for ROS 1

### DIFF
--- a/launch/gscam_v4l.launch
+++ b/launch/gscam_v4l.launch
@@ -3,17 +3,28 @@
 
 <launch>
 
-  <arg name="camera_name"/>  
+  <arg name="camera_name"
+       default="camera"/>
   <arg name="device"
        default="/dev/video0"/>
   <arg name="camera_info_url"
-       default="package://$(arg camera_name)/calibrations/camera.yaml"/>
+       default="package://gscam/examples/uncalibrated_parameters.ini"/>
   <arg name="mono_proc"
        default="False"/>
   <arg name="images_per_second"
-       default="30"/>
+       default="0"/>
+  <arg name="crop_top"
+       default="0"/>
+  <arg name="crop_bottom"
+       default="0"/>
+  <arg name="crop_left"
+       default="0"/>
+  <arg name="crop_right"
+       default="0"/>
   <arg name="deinterlace"
        default="True"/>
+  <arg name="glimagesink"
+       default="False"/>
 
   <!-- generate dummy arguments to build the gscam_config -->
   <arg name="_gscam_videorate"
@@ -23,6 +34,13 @@
        unless="$(eval images_per_second > 0)"
        default=""/>
 
+  <arg name="_gscam_videocrop"
+       if="$(eval ((crop_top > 0) or (crop_bottom > 0) or (crop_left  > 0) or (crop_right > 0)))"
+       default=" ! videocrop top=$(arg crop_top) bottom=$(arg crop_bottom) left=$(arg crop_left) right=$(arg crop_right)"/>
+  <arg name="_gscam_videocrop"
+       unless="$(eval ((crop_top > 0) or (crop_bottom > 0) or (crop_left > 0) or (crop_right > 0)))"
+       default=""/>
+
   <arg name="_gscam_deinterlace"
        if="$(arg deinterlace)"
        default="! deinterlace "/>
@@ -30,7 +48,14 @@
        unless="$(arg deinterlace)"
        default=""/>
 
-  <node name="v4l_test_gscam"
+  <arg name="_gscam_glimagesink"
+       if="$(arg glimagesink)"
+       default="! tee name=t  t. ! queue ! glimagesink force-aspect-ratio=false t. ! queue "/>
+  <arg name="_gscam_glimagesink"
+       unless="$(arg glimagesink)"
+       default=""/>
+
+  <node name="$(arg camera_name)"
         pkg="gscam"
         type="gscam"
 	output="screen">
@@ -40,7 +65,7 @@
 	   value="$(arg camera_info_url)"/>
     <!-- different gscam_config depending on parameters -->
     <param name="gscam_config"
-	   value="v4l2src device=$(arg device) $(arg _gscam_videorate) $(arg _gscam_deinterlace) ! videoconvert"/>
+	   value="v4l2src device=$(arg device) $(arg _gscam_videorate) $(arg _gscam_videocrop) $(arg _gscam_deinterlace) $(arg _gscam_glimagesink) ! videoconvert"/>
     <param name="frame_id"
 	   value="/$(arg camera_name)_frame"/>
     <param name="sync_sink"
@@ -61,5 +86,13 @@
 	pkg="tf"
 	type="static_transform_publisher"
 	args="1 2 3 0 -3.141 0 /world /$(arg camera_name) 10"/>
+
+  <!-- display video using simple ros image_view -->
+  <!-- <node name="$(arg camera_name)_test"
+	pkg="image_view"
+	type="image_view"
+	args="image:=/$(arg camera_name)/image_raw">
+    <param name="autosize" value="True" />
+  </node> -->
 
 </launch>

--- a/launch/gscam_v4l_stereo.launch
+++ b/launch/gscam_v4l_stereo.launch
@@ -1,0 +1,95 @@
+<!-- -*- mode: XML -*- -->
+
+<launch>
+
+  <!-- Set this to your camera's name -->
+  <arg name="stereo_rig_name"/>
+  <arg name="left_name"
+       default="left"/>
+  <arg name="left_device"
+       default="/dev/video0"/>
+  <arg name="right_name"
+       default="right"/>
+  <arg name="right_device"
+       default="/dev/video2"/>
+  <arg name="images_per_second"
+       default="0"/>
+  <arg name="crop_top"
+       default="0"/>
+  <arg name="crop_bottom"
+       default="0"/>
+  <arg name="crop_left"
+       default="0"/>
+  <arg name="crop_right"
+       default="0"/>
+  <arg name="deinterlace"
+       default="True"/>
+  <arg name="glimagesink"
+       default="False"/>
+  <arg name="stereo_proc"
+       default="False"/>
+
+  <!-- left camera driver node -->
+  <include
+      file="$(find dvrk_video)/launch/gscam_v4l.launch"
+      ns="$(arg stereo_rig_name)">
+    <arg name="camera_name"
+	 value="$(arg left_name)"/>
+    <arg name="device"
+	 value="$(arg left_device)"/>
+    <arg name="camera_info_url"
+	 value="package://$(arg stereo_rig_name)/calibrations/left.yaml"/>
+    <!-- pass through -->
+    <arg name="images_per_second"
+	 value="$(arg images_per_second)"/>
+    <arg name="crop_top"
+	 default="$(arg crop_top)"/>
+    <arg name="crop_bottom"
+	 default="$(arg crop_bottom)"/>
+    <arg name="crop_left"
+	 default="$(arg crop_left)"/>
+    <arg name="crop_right"
+	 default="$(arg crop_right)"/>
+    <arg name="deinterlace"
+	 value="$(arg deinterlace)"/>
+    <arg name="glimagesink"
+	 value="$(arg glimagesink)"/>
+  </include>
+
+  <!-- right camera driver node -->
+  <include
+      file="$(find dvrk_video)/launch/gscam_v4l.launch"
+      ns="$(arg stereo_rig_name)">
+    <arg name="camera_name"
+	 value="$(arg right_name)"/>
+    <arg name="device"
+	 value="$(arg right_device)"/>
+    <arg name="camera_info_url"
+	 value="package://$(arg stereo_rig_name)/calibrations/right.yaml"/>
+    <!-- pass through -->
+    <arg name="images_per_second"
+	 value="$(arg images_per_second)"/>
+    <arg name="crop_top"
+	 default="$(arg crop_top)"/>
+    <arg name="crop_bottom"
+	 default="$(arg crop_bottom)"/>
+    <arg name="crop_left"
+	 default="$(arg crop_left)"/>
+    <arg name="crop_right"
+	 default="$(arg crop_right)"/>
+    <arg name="deinterlace"
+	 value="$(arg deinterlace)"/>
+    <arg name="glimagesink"
+	 value="$(arg glimagesink)"/>
+  </include>
+
+  <!-- stereo image processing -->
+  <node if="$(arg stereo_proc)"
+	name="stereo_proc"
+	ns="$(arg stereo_rig_name)"
+	pkg="stereo_image_proc"
+	type="stereo_image_proc"
+	output="screen">
+  </node>
+
+</launch>

--- a/launch/v4l_stereo_1280x1024.launch
+++ b/launch/v4l_stereo_1280x1024.launch
@@ -1,0 +1,62 @@
+<!-- -*- mode: XML -*- -->
+
+<launch>
+
+  <!-- Set the name -->
+  <arg name="stereo_rig_name"/>
+  <arg name="left_device"
+       default="/dev/video0"/>
+  <arg name="right_device"
+       default="/dev/video2"/>
+  <arg name="images_per_second"
+       default="0"/>
+  <arg name="stereo_proc"
+       default="False"/>
+
+  <!-- set lower default rate if stereo proc is activated -->
+  <arg name="_images_per_second"
+       if="$(eval ((images_per_second == 0) and stereo_proc))"
+       default="15"/>
+  <arg name="_images_per_second"
+       unless="$(eval ((images_per_second == 0) and stereo_proc))"
+       default="$(arg images_per_second)"/>
+
+  <!-- camera driver nodes -->
+  <include file="$(find dvrk_video)/launch/gscam_v4l_stereo.launch">
+    <arg name="stereo_rig_name"
+	 value="$(arg stereo_rig_name)"/>
+    <arg name="left_device"
+	 value="$(arg left_device)"/>
+    <arg name="right_device"
+	 value = "$(arg right_device)"/>
+    <arg name="images_per_second"
+	 value="$(arg _images_per_second)"/>
+    <arg name="deinterlace"
+	 value="True"/>
+    <arg name="stereo_proc"
+	 default="$(arg stereo_proc)"/>
+    <arg name="crop_top"
+	 value="88"/>
+    <arg name="crop_bottom"
+	 value="88"/>
+    <arg name="crop_left"
+	 value="320"/>
+    <arg name="crop_right"
+	 value="320"/>
+  </include>
+
+  <!-- display video using simple ros image_view -->
+  <node name="dvrk_left_view"
+	pkg="image_view"
+	type="image_view"
+	args="image:=/$(arg stereo_rig_name)/left/image_raw">
+    <param name="autosize" value="True" />
+  </node>
+  <node name="dvrk_right_view"
+	pkg="image_view"
+	type="image_view"
+	args="image:=/$(arg stereo_rig_name)/right/image_raw">
+    <param name="autosize" value="True" />
+  </node>
+
+</launch>

--- a/launch/v4l_stereo_full.launch
+++ b/launch/v4l_stereo_full.launch
@@ -1,0 +1,54 @@
+<!-- -*- mode: XML -*- -->
+
+<launch>
+
+  <!-- Set the name -->
+  <arg name="stereo_rig_name"/>
+  <arg name="left_device"
+       default="/dev/video0"/>
+  <arg name="right_device"
+       default="/dev/video2"/>
+  <arg name="images_per_second"
+       default="0"/>
+  <arg name="stereo_proc"
+       default="False"/>
+
+  <!-- set lower default rate if stereo proc is activated -->
+  <arg name="_images_per_second"
+       if="$(eval ((images_per_second == 0) and stereo_proc))"
+       default="15"/>
+  <arg name="_images_per_second"
+       unless="$(eval ((images_per_second == 0) and stereo_proc))"
+       default="$(arg images_per_second)"/>
+
+  <!-- camera driver nodes -->
+  <include file="$(find dvrk_video)/launch/gscam_v4l_stereo.launch">
+    <arg name="stereo_rig_name"
+	 value="$(arg stereo_rig_name)"/>
+    <arg name="left_device"
+	 value="$(arg left_device)"/>
+    <arg name="right_device"
+	 value = "$(arg right_device)"/>
+    <arg name="images_per_second"
+	 value="$(arg _images_per_second)"/>
+    <arg name="deinterlace"
+	 value="True"/>
+    <arg name="stereo_proc"
+	 default="$(arg stereo_proc)"/>
+  </include>
+
+  <!-- display video using simple ros image_view -->
+  <node name="dvrk_left_view"
+	pkg="image_view"
+	type="image_view"
+	args="image:=/$(arg stereo_rig_name)/left/image_raw">
+    <param name="autosize" value="True" />
+  </node>
+  <node name="dvrk_right_view"
+	pkg="image_view"
+	type="image_view"
+	args="image:=/$(arg stereo_rig_name)/right/image_raw">
+    <param name="autosize" value="True" />
+  </node>
+
+</launch>

--- a/launch/v4l_stereo_goovis.launch
+++ b/launch/v4l_stereo_goovis.launch
@@ -1,0 +1,43 @@
+<!-- -*- mode: XML -*- -->
+
+<launch>
+
+  <!-- Set the name -->
+  <arg name="stereo_rig_name"/>
+  <arg name="left_device"
+       default="/dev/video0"/>
+  <arg name="right_device"
+       default="/dev/video2"/>
+  <arg name="images_per_second"
+       default="0"/>
+  <arg name="stereo_proc"
+       default="False"/>
+
+  <!-- set lower default rate if stereo proc is activated -->
+  <arg name="_images_per_second"
+       if="$(eval ((images_per_second == 0) and stereo_proc))"
+       default="15"/>
+  <arg name="_images_per_second"
+       unless="$(eval ((images_per_second == 0) and stereo_proc))"
+       default="$(arg images_per_second)"/>
+
+  <!-- camera driver nodes -->
+  <include file="$(find dvrk_video)/launch/gscam_v4l_stereo.launch">
+    <arg name="stereo_rig_name"
+	 value="$(arg stereo_rig_name)"/>
+    <arg name="left_device"
+	 value="$(arg left_device)"/>
+    <arg name="right_device"
+	 value = "$(arg right_device)"/>
+    <arg name="images_per_second"
+	 value="$(arg _images_per_second)"/>
+    <arg name="deinterlace"
+	 value="True"/>
+    <arg name="glimagesink"
+	 value="True"/>
+    <arg name="stereo_proc"
+	 default="$(arg stereo_proc)"/>
+
+  </include>
+
+</launch>

--- a/launch/v4l_stereo_goovis.launch
+++ b/launch/v4l_stereo_goovis.launch
@@ -5,9 +5,9 @@
   <!-- Set the name -->
   <arg name="stereo_rig_name"/>
   <arg name="left_device"
-       default="/dev/video0"/>
+       default="/dev/csr-left"/>
   <arg name="right_device"
-       default="/dev/video2"/>
+       default="/dev/csr-right"/>
   <arg name="images_per_second"
        default="0"/>
   <arg name="stereo_proc"

--- a/launch/v4l_stereo_goovis.launch
+++ b/launch/v4l_stereo_goovis.launch
@@ -37,6 +37,10 @@
 	 value="True"/>
     <arg name="stereo_proc"
 	 default="$(arg stereo_proc)"/>
+    <arg name="crop_top"
+	 value="60"/>
+    <arg name="crop_bottom"
+	 value="60"/>
 
   </include>
 

--- a/ros2/launch/gscam_v4l.launch.py
+++ b/ros2/launch/gscam_v4l.launch.py
@@ -1,111 +1,98 @@
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
-# from launch_ros.actions import ComposableNodeContainer
+from launch.actions import DeclareLaunchArgument, OpaqueFunction
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
-from launch.substitutions import LaunchConfiguration, PythonExpression
+
+
+def _build_gst_pipeline(device: str,
+                        fps: int,
+                        crop_top: int,
+                        crop_bottom: int,
+                        crop_left: int,
+                        crop_right: int,
+                        deinterlace: bool,
+                        glimagesink: bool) -> str:
+    '''
+    Build the conditional GStreamer string assembly
+    device: device to load
+    fps: desired image refreshing rate in frame per second
+    crop_top: crop distance in pixel from top edge
+    crop_bottom: crop distance in pixel from bottom edge
+    crop_left: crop distance in pixel from left edge
+    crop_right: crop distance in pixel from right edge
+    deinterlace: whether enable deinterlace
+    glimagesink: whether using opengl
+    output: gstreamer string
+    '''
+    pipe = f"v4l2src device={device} do-timestamp=true"
+    if fps > 0:
+        pipe += f" ! videorate ! video/x-raw,framerate={fps}/1"
+    if any(v > 0 for v in (crop_top, crop_bottom, crop_left, crop_right)):
+        pipe += (f" ! videocrop top={crop_top} bottom={crop_bottom} "
+                 f"left={crop_left} right={crop_right}")
+    if deinterlace:
+        pipe += " ! deinterlace"
+        
+    pipe += " ! videoconvert"
+    if glimagesink:
+        pipe += " ! tee name=t t. ! queue ! glimagesink force-aspect-ratio=false t. ! queue"
+    return pipe
+
+
+def _launch_gscam_node(context, *, prefix="", suffix=""):
+    # Pull evaluated launch args
+    cam_name    = LaunchConfiguration('camera_name').perform(context)
+    device      = LaunchConfiguration('device').perform(context)
+    cam_info    = LaunchConfiguration('camera_info_url').perform(context)
+    fps         = int(LaunchConfiguration('images_per_second').perform(context))
+    crop_top    = int(LaunchConfiguration('crop_top').perform(context))
+    crop_bottom = int(LaunchConfiguration('crop_bottom').perform(context))
+    crop_left   = int(LaunchConfiguration('crop_left').perform(context))
+    crop_right  = int(LaunchConfiguration('crop_right').perform(context))
+    deint       = LaunchConfiguration('deinterlace').perform(context).lower() in ('true','1','yes')
+    glsink      = LaunchConfiguration('glimagesink').perform(context).lower() in ('true','1','yes')
+
+    gst = _build_gst_pipeline(device, fps, crop_top, crop_bottom, crop_left, crop_right, deint, glsink)
+
+    frame_id = f"/{cam_name}_frame"
+
+    # remap gscam's default camera/* topics back to the ROS2 topics like /<ns>/image_raw etc
+    remaps = [
+        ('camera/image_raw',     'image_raw'),
+        ('camera/camera_info',   'camera_info'),
+        ('camera/set_camera_info','set_camera_info'),
+    ]
+
+    node = Node(
+        package='gscam',
+        executable='gscam_node',
+        name=cam_name if not prefix else f"{prefix}{cam_name}{suffix}",
+        namespace=cam_name,  # Push into its own namespace so topics become <name>/image_raw
+        output='screen',
+        parameters=[{
+            'camera_name': cam_name,
+            'camera_info_url': cam_info,
+            'gscam_config': gst,
+            'frame_id': frame_id,
+            'sync_sink': False,
+            'use_gst_timestamps': True,
+        }],
+        remappings=remaps,
+    )
+    return [node]
+
 
 def generate_launch_description():
-    camera_info_url = LaunchConfiguration('camera_info_url',
-                                          default = 'package://gscam/examples/uncalibrated_parameters.ini')
-
-    device_configuration = LaunchConfiguration('device')
-    device_argument = DeclareLaunchArgument(
-        'device',
-        description = 'v4l2 device to use',
-        default_value = '/dev/video0')
-
-    deinterlace_configuration = LaunchConfiguration('deinterlace')
-    deinterlace_argument = DeclareLaunchArgument(
-        'deinterlace',
-        description = 'add deinterlace filter to the gstreamer pipeline',
-        default_value = 'False',
-        choices = ['True', 'False', '1', '0'])
-
-    gscam_node = Node(
-        package = 'gscam',
-        executable = 'gscam_node',
-        output = 'screen',
-        parameters = [{
-            'gscam_config': PythonExpression([
-                '"v4l2src device=" + "', device_configuration, '"',
-                ' + (" ! deinterlace" if ', deinterlace_configuration, ' else "")',
-                ' + " ! videoconvert"'
-            ]),
-            'camera_info_url': camera_info_url,
-        }],
-        )
-
     return LaunchDescription([
-        deinterlace_argument,
-        device_argument,
-        gscam_node
+        DeclareLaunchArgument('camera_name', default_value='camera'),
+        DeclareLaunchArgument('device', default_value='/dev/video0'),
+        DeclareLaunchArgument('camera_info_url', default_value=''),
+        DeclareLaunchArgument('images_per_second', default_value='30'),
+        DeclareLaunchArgument('crop_top', default_value='0'),
+        DeclareLaunchArgument('crop_bottom', default_value='0'),
+        DeclareLaunchArgument('crop_left', default_value='0'),
+        DeclareLaunchArgument('crop_right', default_value='0'),
+        DeclareLaunchArgument('deinterlace', default_value='True'),
+        DeclareLaunchArgument('glimagesink', default_value='False'),
+        OpaqueFunction(function=_launch_gscam_node),
     ])
-
-
-
-    # return LaunchDescription([
-    #     launch_argument_device,
-    #     ComposableNodeContainer(
-    #         name = 'gscam_container',
-    #         namespace = '',
-    #         package = 'rclcpp_components',
-    #         executable = 'component_container',
-    #         composable_node_descriptions = [
-
-    #         # GSCam driver
-    #         ComposableNode(
-    #             package = 'gscam',
-    #             plugin = 'gscam::GSCam',
-    #             name = 'gscam_node',
-    #             parameters = [{
-    #                 'gscam_config': gscam_config,
-    #                 'camera_info_url': camera_info_url,
-    #             }],
-    #             extra_arguments = [{
-    #                 'use_intra_process_comms': True,
-    #             }],
-    #         ),
-
-    #         # # Bayer color decoding
-    #         # ComposableNode(
-    #         #     package = 'image_proc',
-    #         #     plugin = 'image_proc::DebayerNode',
-    #         #     name = 'debayer_node',
-    #         #     namespace = 'camera',
-    #         #     extra_arguments = [{
-    #         #         'use_intra_process_comms': True,
-    #         #     }],
-    #         # ),
-
-    #         # # Mono rectification
-    #         # ComposableNode(
-    #         #     package = 'image_proc',
-    #         #     plugin = 'image_proc::RectifyNode',
-    #         #     name = 'mono_rectify_node',
-    #         #     namespace = 'camera',
-    #         #     extra_arguments = [{
-    #         #         'use_intra_process_comms': True,
-    #         #     }],
-    #         #     remappings = [
-    #         #         ('image', 'image_mono'),
-    #         #         ('image_rect', 'image_rect_mono'),
-    #         #     ],
-    #         # ),
-
-    #         # # Color rectification
-    #         # ComposableNode(
-    #         #     package = 'image_proc',
-    #         #     plugin = 'image_proc::RectifyNode',
-    #         #     name = 'color_rectify_node',
-    #         #     namespace = 'camera',
-    #         #     extra_arguments = [{
-    #         #         'use_intra_process_comms': True,
-    #         #     }],
-    #         #     remappings = [
-    #         #         ('image', 'image_color'),
-    #         #         ('image_rect', 'image_rect_color'),
-    #         #     ],
-    #         # ),
-    #     ],
-    #     output = 'screen',
-    # )])

--- a/ros2/launch/gscam_v4l_stereo.launch.py
+++ b/ros2/launch/gscam_v4l_stereo.launch.py
@@ -1,0 +1,125 @@
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, GroupAction, IncludeLaunchDescription
+from launch.conditions import IfCondition
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import PathJoinSubstitution, LaunchConfiguration
+from launch_ros.actions import Node, ComposableNodeContainer, PushRosNamespace
+from launch_ros.substitutions import FindPackageShare
+from launch_ros.descriptions import ComposableNode
+
+def generate_launch_description():
+    stereo_rig_name = DeclareLaunchArgument('stereo_rig_name', default_value='stereo')
+    left_name       = DeclareLaunchArgument('left_name',  default_value='left')
+    right_name      = DeclareLaunchArgument('right_name', default_value='right')
+    left_device     = DeclareLaunchArgument('left_device',  default_value='/dev/video0')
+    right_device    = DeclareLaunchArgument('right_device', default_value='/dev/video2')
+    images_per_sec  = DeclareLaunchArgument('images_per_second', default_value='0')
+    stereo_proc     = DeclareLaunchArgument('stereo_proc', default_value='False')
+    crop_top        = DeclareLaunchArgument('crop_top', default_value='0')
+    crop_bottom     = DeclareLaunchArgument('crop_bottom', default_value='0')
+    crop_left       = DeclareLaunchArgument('crop_left', default_value='0')
+    crop_right      = DeclareLaunchArgument('crop_right', default_value='0')
+    deinterlace     = DeclareLaunchArgument('deinterlace', default_value='True')
+    glimagesink     = DeclareLaunchArgument('glimagesink', default_value='False')
+    left_cam_info   = DeclareLaunchArgument('left_camera_info_url', default_value='')
+    right_cam_info  = DeclareLaunchArgument('right_camera_info_url', default_value='')
+
+    # Path to monocular helper (this file) — assumes same package; adjust if different
+    mono_launch = PathJoinSubstitution([FindPackageShare('dvrk_video'), 'launch', 'gscam_v4l.launch.py'])
+
+    # define the namespace
+    left_include = GroupAction([
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(mono_launch),
+            launch_arguments={
+                'camera_name':     LaunchConfiguration('left_name'),
+                'device':          LaunchConfiguration('left_device'),
+                'camera_info_url': LaunchConfiguration('left_camera_info_url'),
+                'images_per_second': LaunchConfiguration('images_per_second'),
+                'crop_top':        LaunchConfiguration('crop_top'),
+                'crop_bottom':     LaunchConfiguration('crop_bottom'),
+                'crop_left':       LaunchConfiguration('crop_left'),
+                'crop_right':      LaunchConfiguration('crop_right'),
+                'deinterlace':     LaunchConfiguration('deinterlace'),
+                'glimagesink':     LaunchConfiguration('glimagesink'),
+            }.items(),
+        ),
+    ], scoped=True,)
+
+    right_include = GroupAction([
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(mono_launch),
+            launch_arguments={
+                'camera_name':     LaunchConfiguration('right_name'),
+                'device':          LaunchConfiguration('right_device'),
+                'camera_info_url': LaunchConfiguration('right_camera_info_url'),
+                'images_per_second': LaunchConfiguration('images_per_second'),
+                'crop_top':        LaunchConfiguration('crop_top'),
+                'crop_bottom':     LaunchConfiguration('crop_bottom'),
+                'crop_left':       LaunchConfiguration('crop_left'),
+                'crop_right':      LaunchConfiguration('crop_right'),
+                'deinterlace':     LaunchConfiguration('deinterlace'),
+                'glimagesink':     LaunchConfiguration('glimagesink'),
+            }.items(),
+        ),
+    ], scoped=True,)
+    
+    left_rect = ComposableNode(
+        package='image_proc',
+        plugin='image_proc::RectifyNode',
+        name='left_rectify',
+        namespace=[LaunchConfiguration('stereo_rig_name'), '/', LaunchConfiguration('left_name')],
+        remappings=[('image', 'image_raw'), ('image_rect', 'image_rect')],
+    )
+    right_rect = ComposableNode(
+        package='image_proc',
+        plugin='image_proc::RectifyNode',
+        name='right_rectify',
+        namespace=[LaunchConfiguration('stereo_rig_name'), '/', LaunchConfiguration('right_name')],
+        remappings=[('image', 'image_raw'), ('image_rect', 'image_rect')],
+    )
+    # Disparity + point cloud components live in stereo_image_proc pkg
+    disparity = ComposableNode(
+        package='stereo_image_proc',
+        plugin='stereo_image_proc::DisparityNode',
+        name='disparity_node',
+        namespace=LaunchConfiguration('stereo_rig_name'),
+        remappings=[
+            ('left/image_rect',  [LaunchConfiguration('left_name'), '/image_rect']),
+            ('right/image_rect', [LaunchConfiguration('right_name'), '/image_rect']),
+            ('left/camera_info', [LaunchConfiguration('left_name'), '/camera_info']),
+            ('right/camera_info',[LaunchConfiguration('right_name'), '/camera_info']),
+        ],
+    )
+    point_cloud = ComposableNode(
+        package='stereo_image_proc',
+        plugin='stereo_image_proc::PointCloudNode',
+        name='point_cloud_node',
+        namespace=LaunchConfiguration('stereo_rig_name'),
+        remappings=[
+            ('left/image_rect_color',  [LaunchConfiguration('left_name'), '/image_rect']),
+            ('right/image_rect',       [LaunchConfiguration('right_name'), '/image_rect']),
+            ('left/camera_info',       [LaunchConfiguration('left_name'), '/camera_info']),
+            ('right/camera_info',      [LaunchConfiguration('right_name'), '/camera_info']),
+        ],
+    )
+
+    stereo_container = ComposableNodeContainer(
+        condition=IfCondition(LaunchConfiguration('stereo_proc')),
+        name='stereo_proc_container',
+        namespace=LaunchConfiguration('stereo_rig_name'),
+        package='rclcpp_components',
+        executable='component_container_mt',
+        composable_node_descriptions=[left_rect, right_rect, disparity, point_cloud],
+        output='screen',
+    )
+
+    return LaunchDescription([
+        stereo_rig_name, left_name, right_name,
+        left_device, right_device, images_per_sec, stereo_proc,
+        crop_top, crop_bottom, crop_left, crop_right, deinterlace, glimagesink,
+        left_cam_info, right_cam_info,
+        GroupAction(actions=[PushRosNamespace(LaunchConfiguration('stereo_rig_name')), left_include]),
+        GroupAction(actions=[PushRosNamespace(LaunchConfiguration('stereo_rig_name')), right_include]),
+        stereo_container,
+    ])

--- a/ros2/launch/v4l_stereo_1280x960.launch.py
+++ b/ros2/launch/v4l_stereo_1280x960.launch.py
@@ -1,0 +1,113 @@
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution, TextSubstitution
+from launch_ros.substitutions import FindPackageShare
+from launch_ros.actions import Node
+
+
+
+# def generate_launch_description():
+#     stereo_rig_name = DeclareLaunchArgument('stereo_rig_name', default_value='stereo')
+#     # Example: full resolution; you can override on CLI if needed.
+#     images_per_sec  = DeclareLaunchArgument('images_per_second', default_value='0')
+#     stereo_proc     = DeclareLaunchArgument('stereo_proc', default_value='False')
+#     left_device     = DeclareLaunchArgument('left_device', default_value='/dev/video0')
+#     right_device    = DeclareLaunchArgument('right_device', default_value='/dev/video2')
+
+#     stereo_launch = PathJoinSubstitution([FindPackageShare('dvrk_video'), 'launch', 'gscam_v4l_stereo.launch.py'])
+
+#     return LaunchDescription([
+#         stereo_rig_name, images_per_sec, stereo_proc, left_device, right_device,
+#         IncludeLaunchDescription(PythonLaunchDescriptionSource(stereo_launch), launch_arguments={
+#             'stereo_rig_name': LaunchConfiguration('stereo_rig_name'),
+#             'left_device':     LaunchConfiguration('left_device'),
+#             'right_device':    LaunchConfiguration('right_device'),
+#             'images_per_second': LaunchConfiguration('images_per_second'),
+#             'stereo_proc':     LaunchConfiguration('stereo_proc'),
+#             'crop_top':        '0',
+#             'crop_bottom':     '0',
+#             'crop_left':       '0',
+#             'crop_right':      '0',
+#             'deinterlace':     'True',
+#             'glimagesink':     'False',
+#         }.items()),
+#     ])
+
+
+def generate_launch_description():
+    #
+    # Launch Arguments (pass‑through to the underlying stereo bringup)
+    #
+    stereo_rig_name = DeclareLaunchArgument('stereo_rig_name', default_value='stereo',
+                                            description='Top‑level namespace for the stereo rig.')
+    images_per_sec  = DeclareLaunchArgument('images_per_second', default_value='0',
+                                            description='FPS throttle; 0=unlimited (device default).')
+    stereo_proc     = DeclareLaunchArgument('stereo_proc', default_value='False',
+                                            description='Enable downstream stereo processing pipeline (rectify/disparity).')
+    left_device     = DeclareLaunchArgument('left_device', default_value='/dev/video0',
+                                            description='Left V4L2 device path.')
+    right_device    = DeclareLaunchArgument('right_device', default_value='/dev/video2',
+                                            description='Right V4L2 device path.')
+
+    left_name  = LaunchConfiguration('left_name')
+    right_name = LaunchConfiguration('right_name')
+
+    stereo_launch = PathJoinSubstitution([
+        FindPackageShare('dvrk_video'), 'launch', 'gscam_v4l_stereo.launch.py'
+    ])
+
+    stereo_include = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(stereo_launch),
+        launch_arguments={
+            'stereo_rig_name': LaunchConfiguration('stereo_rig_name'),
+            'left_device':     LaunchConfiguration('left_device'),
+            'right_device':    LaunchConfiguration('right_device'),
+            'images_per_second': LaunchConfiguration('images_per_second'),
+            'stereo_proc':     LaunchConfiguration('stereo_proc'),
+            'crop_top':        '60',
+            'crop_bottom':     '60',
+            'crop_left':       '310',
+            'crop_right':      '310',
+            'deinterlace':     'True',
+            'glimagesink':     'False',
+        }.items()
+    )
+
+    left_view = Node(
+        package='image_view',
+        executable='image_view',
+        name='left_view',
+        namespace=LaunchConfiguration('stereo_rig_name'),
+        remappings=[
+            ('image', [left_name, TextSubstitution(text='/image_raw')]),
+        ],
+        parameters=[{'autosize': True}],
+        output='screen',
+    )
+
+    right_view = Node(
+        package='image_view',
+        executable='image_view',
+        name='right_view',
+        namespace=LaunchConfiguration('stereo_rig_name'),
+        remappings=[
+            ('image', [right_name, TextSubstitution(text='/image_raw')]),
+        ],
+        parameters=[{'autosize': True}],
+        output='screen',
+    )
+
+    #
+    # Assemble and return
+    #
+    return LaunchDescription([
+        stereo_rig_name,
+        images_per_sec,
+        stereo_proc,
+        left_device,
+        right_device,
+        stereo_include,
+        left_view,
+        right_view,
+    ])

--- a/ros2/launch/v4l_stereo_1280x960.launch.py
+++ b/ros2/launch/v4l_stereo_1280x960.launch.py
@@ -39,15 +39,15 @@ def generate_launch_description():
     #
     # Launch Arguments (pass‑through to the underlying stereo bringup)
     #
-    stereo_rig_name = DeclareLaunchArgument('stereo_rig_name', default_value='stereo',
+    stereo_rig_name = DeclareLaunchArgument('stereo_rig_name', default_value='dvrk',
                                             description='Top‑level namespace for the stereo rig.')
     images_per_sec  = DeclareLaunchArgument('images_per_second', default_value='0',
                                             description='FPS throttle; 0=unlimited (device default).')
     stereo_proc     = DeclareLaunchArgument('stereo_proc', default_value='False',
                                             description='Enable downstream stereo processing pipeline (rectify/disparity).')
-    left_device     = DeclareLaunchArgument('left_device', default_value='/dev/video0',
+    left_device     = DeclareLaunchArgument('left_device', default_value='/dev/video-left',
                                             description='Left V4L2 device path.')
-    right_device    = DeclareLaunchArgument('right_device', default_value='/dev/video2',
+    right_device    = DeclareLaunchArgument('right_device', default_value='/dev/video-right',
                                             description='Right V4L2 device path.')
 
     left_name  = LaunchConfiguration('left_name')

--- a/ros2/launch/v4l_stereo_full.launch.py
+++ b/ros2/launch/v4l_stereo_full.launch.py
@@ -1,0 +1,112 @@
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution, TextSubstitution
+from launch_ros.substitutions import FindPackageShare
+from launch_ros.actions import Node
+
+
+
+# def generate_launch_description():
+#     stereo_rig_name = DeclareLaunchArgument('stereo_rig_name', default_value='stereo')
+#     # Example: full resolution; you can override on CLI if needed.
+#     images_per_sec  = DeclareLaunchArgument('images_per_second', default_value='0')
+#     stereo_proc     = DeclareLaunchArgument('stereo_proc', default_value='False')
+#     left_device     = DeclareLaunchArgument('left_device', default_value='/dev/video0')
+#     right_device    = DeclareLaunchArgument('right_device', default_value='/dev/video2')
+
+#     stereo_launch = PathJoinSubstitution([FindPackageShare('dvrk_video'), 'launch', 'gscam_v4l_stereo.launch.py'])
+
+#     return LaunchDescription([
+#         stereo_rig_name, images_per_sec, stereo_proc, left_device, right_device,
+#         IncludeLaunchDescription(PythonLaunchDescriptionSource(stereo_launch), launch_arguments={
+#             'stereo_rig_name': LaunchConfiguration('stereo_rig_name'),
+#             'left_device':     LaunchConfiguration('left_device'),
+#             'right_device':    LaunchConfiguration('right_device'),
+#             'images_per_second': LaunchConfiguration('images_per_second'),
+#             'stereo_proc':     LaunchConfiguration('stereo_proc'),
+#             'crop_top':        '0',
+#             'crop_bottom':     '0',
+#             'crop_left':       '0',
+#             'crop_right':      '0',
+#             'deinterlace':     'True',
+#             'glimagesink':     'False',
+#         }.items()),
+#     ])
+
+
+def generate_launch_description():
+    #
+    # Launch Arguments (pass‑through to the underlying stereo bringup)
+    #
+    stereo_rig_name = DeclareLaunchArgument('stereo_rig_name', default_value='stereo',
+                                            description='Top‑level namespace for the stereo rig.')
+    images_per_sec  = DeclareLaunchArgument('images_per_second', default_value='0',
+                                            description='FPS throttle; 0=unlimited (device default).')
+    stereo_proc     = DeclareLaunchArgument('stereo_proc', default_value='False',
+                                            description='Enable downstream stereo processing pipeline (rectify/disparity).')
+    left_device     = DeclareLaunchArgument('left_device', default_value='/dev/video0',
+                                            description='Left V4L2 device path.')
+    right_device    = DeclareLaunchArgument('right_device', default_value='/dev/video2',
+                                            description='Right V4L2 device path.')
+
+    left_name  = LaunchConfiguration('left_name')
+    right_name = LaunchConfiguration('right_name')
+
+    stereo_launch = PathJoinSubstitution([
+        FindPackageShare('dvrk_video'), 'launch', 'gscam_v4l_stereo.launch.py'
+    ])
+
+    stereo_include = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(stereo_launch),
+        launch_arguments={
+            'stereo_rig_name': LaunchConfiguration('stereo_rig_name'),
+            'left_device':     LaunchConfiguration('left_device'),
+            'right_device':    LaunchConfiguration('right_device'),
+            'images_per_second': LaunchConfiguration('images_per_second'),
+            'stereo_proc':     LaunchConfiguration('stereo_proc'),
+            # Full‑resolution: no cropping, deinterlace on, headless (no glimagesink tee)
+            'crop_top':        '0',
+            'crop_bottom':     '0',
+            'crop_left':       '0',
+            'crop_right':      '0',
+            'deinterlace':     'True',
+            'glimagesink':     'False',
+        }.items()
+    )
+
+    left_view = Node(
+        package='image_view',
+        executable='image_view',
+        name='left_view',
+        namespace=LaunchConfiguration('stereo_rig_name'),
+        remappings=[
+            ('image', [left_name, TextSubstitution(text='/image_raw')]),
+        ],
+        output='screen',
+    )
+
+    right_view = Node(
+        package='image_view',
+        executable='image_view',
+        name='right_view',
+        namespace=LaunchConfiguration('stereo_rig_name'),
+        remappings=[
+            ('image', [right_name, TextSubstitution(text='/image_raw')]),
+        ],
+        output='screen',
+    )
+
+    #
+    # Assemble and return
+    #
+    return LaunchDescription([
+        stereo_rig_name,
+        images_per_sec,
+        stereo_proc,
+        left_device,
+        right_device,
+        stereo_include,
+        left_view,
+        right_view,
+    ])

--- a/ros2/launch/v4l_stereo_full.launch.py
+++ b/ros2/launch/v4l_stereo_full.launch.py
@@ -39,15 +39,15 @@ def generate_launch_description():
     #
     # Launch Arguments (pass‑through to the underlying stereo bringup)
     #
-    stereo_rig_name = DeclareLaunchArgument('stereo_rig_name', default_value='stereo',
+    stereo_rig_name = DeclareLaunchArgument('stereo_rig_name', default_value='dvrk',
                                             description='Top‑level namespace for the stereo rig.')
     images_per_sec  = DeclareLaunchArgument('images_per_second', default_value='0',
                                             description='FPS throttle; 0=unlimited (device default).')
     stereo_proc     = DeclareLaunchArgument('stereo_proc', default_value='False',
                                             description='Enable downstream stereo processing pipeline (rectify/disparity).')
-    left_device     = DeclareLaunchArgument('left_device', default_value='/dev/video0',
+    left_device     = DeclareLaunchArgument('left_device', default_value='/dev/video-left',
                                             description='Left V4L2 device path.')
-    right_device    = DeclareLaunchArgument('right_device', default_value='/dev/video2',
+    right_device    = DeclareLaunchArgument('right_device', default_value='/dev/video-right',
                                             description='Right V4L2 device path.')
 
     left_name  = LaunchConfiguration('left_name')

--- a/ros2/launch/v4l_stereo_goovis.launch.py
+++ b/ros2/launch/v4l_stereo_goovis.launch.py
@@ -1,0 +1,35 @@
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution, TextSubstitution
+from launch_ros.substitutions import FindPackageShare
+from launch_ros.actions import Node
+
+
+
+def generate_launch_description():
+    stereo_rig_name = DeclareLaunchArgument('stereo_rig_name', default_value='stereo')
+    # Example: full resolution; you can override on CLI if needed.
+    images_per_sec  = DeclareLaunchArgument('images_per_second', default_value='0')
+    stereo_proc     = DeclareLaunchArgument('stereo_proc', default_value='False')
+    left_device     = DeclareLaunchArgument('left_device', default_value='/dev/video0')
+    right_device    = DeclareLaunchArgument('right_device', default_value='/dev/video2')
+
+    stereo_launch = PathJoinSubstitution([FindPackageShare('dvrk_video'), 'launch', 'gscam_v4l_stereo.launch.py'])
+
+    return LaunchDescription([
+        stereo_rig_name, images_per_sec, stereo_proc, left_device, right_device,
+        IncludeLaunchDescription(PythonLaunchDescriptionSource(stereo_launch), launch_arguments={
+            'stereo_rig_name': LaunchConfiguration('stereo_rig_name'),
+            'left_device':     LaunchConfiguration('left_device'),
+            'right_device':    LaunchConfiguration('right_device'),
+            'images_per_second': LaunchConfiguration('images_per_second'),
+            'stereo_proc':     LaunchConfiguration('stereo_proc'),
+            'crop_top':        '0',
+            'crop_bottom':     '0',
+            'crop_left':       '0',
+            'crop_right':      '0',
+            'deinterlace':     'True',
+            'glimagesink':     'True',
+        }.items()),
+    ])

--- a/ros2/launch/v4l_stereo_goovis.launch.py
+++ b/ros2/launch/v4l_stereo_goovis.launch.py
@@ -8,12 +8,12 @@ from launch_ros.actions import Node
 
 
 def generate_launch_description():
-    stereo_rig_name = DeclareLaunchArgument('stereo_rig_name', default_value='stereo')
+    stereo_rig_name = DeclareLaunchArgument('stereo_rig_name', default_value='dvrk')
     # Example: full resolution; you can override on CLI if needed.
     images_per_sec  = DeclareLaunchArgument('images_per_second', default_value='0')
     stereo_proc     = DeclareLaunchArgument('stereo_proc', default_value='False')
-    left_device     = DeclareLaunchArgument('left_device', default_value='/dev/video0')
-    right_device    = DeclareLaunchArgument('right_device', default_value='/dev/video2')
+    left_device     = DeclareLaunchArgument('left_device', default_value='/dev/video-left')
+    right_device    = DeclareLaunchArgument('right_device', default_value='/dev/video-right')
 
     stereo_launch = PathJoinSubstitution([FindPackageShare('dvrk_video'), 'launch', 'gscam_v4l_stereo.launch.py'])
 


### PR DESCRIPTION
Add launch files using v4l2src in gscam.

This update is for the endoscopes (e.g. CornerStone Robotics endoscopes) which the image signal is read via capture cards and  under /dev/video*